### PR TITLE
[WIP] Add product price validation backend example.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "endOfLine": "lf",
   "semi": false,
-  "singleQuote": false,
+  "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "endOfLine": "lf",
   "semi": false,
-  "singleQuote": true,
+  "singleQuote": false,
   "tabWidth": 2,
   "trailingComma": "es5"
 }

--- a/snippets.js/express_server.js
+++ b/snippets.js/express_server.js
@@ -1,30 +1,30 @@
 // Online example: https://runkit.com/thor-stripe/gocommerce-clone-api
-const express = require('express')
+const express = require("express")
 const app = express()
 const port = 3000
 
-const fetch = require('isomorphic-unfetch')
-const DomParser = require('dom-parser')
+const fetch = require("isomorphic-unfetch")
+const DomParser = require("dom-parser")
 const parser = new DomParser()
 
-const stripe = require('stripe')(process.env.JAMSTACK_SECRET_KEY)
+const stripe = require("stripe")(process.env.JAMSTACK_SECRET_KEY)
 
 // Constants
-const SITE_URL = 'https://53806382.ngrok.io/'
+const SITE_URL = "https://53806382.ngrok.io/"
 // Helper functions
 const getProductData = async url => {
   // Get the product meta from the static page
   const doc = await fetch(url).then(async res => {
     const htmlString = await res.text()
-    return parser.parseFromString(htmlString, 'text/html')
+    return parser.parseFromString(htmlString, "text/html")
   })
-  if (doc.getElementsByClassName('gocommerce-product').length !== 1) {
-    throw new Error('None or too many product data declarations!')
+  if (doc.getElementsByClassName("gocommerce-product").length !== 1) {
+    throw new Error("None or too many product data declarations!")
     return
   }
   // Replace HTML special chars
   const jsonString = doc
-    .getElementsByClassName('gocommerce-product')[0]
+    .getElementsByClassName("gocommerce-product")[0]
     .innerHTML.replace(/&quot;/g, `"`)
   return JSON.parse(jsonString)
 }
@@ -47,22 +47,22 @@ const calculateOrderAmount = ({ order, products }) => {
 }
 
 // use body-parser to automatically parse JSON-encoded request bodies
-const bodyParser = require('body-parser')
+const bodyParser = require("body-parser")
 app.use(bodyParser.json())
 
 // Allow cors
-app.use('/', function(req, res, next) {
+app.use("/", function(req, res, next) {
   // Allow requests from localhost.
-  const allowedOrigins = ['http://localhost:9000'] // port that's used when running gatsby serve
+  const allowedOrigins = ["http://localhost:9000"] // port that's used when running gatsby serve
   const origin = req.headers.origin
   if (allowedOrigins.indexOf(origin) > -1) {
-    res.setHeader('Access-Control-Allow-Headers', '*')
-    res.setHeader('Access-Control-Allow-Origin', origin)
+    res.setHeader("Access-Control-Allow-Headers", "*")
+    res.setHeader("Access-Control-Allow-Origin", origin)
   }
   next()
 })
 
-app.post('/pay', async (req, res) => {
+app.post("/pay", async (req, res) => {
   const { order } = req.body
   const skuIds = order.cart.map(item => item.sku)
 
@@ -87,7 +87,7 @@ app.post('/pay', async (req, res) => {
         amount: totalAmount * 100, // TODO zero decimal currency detection
         currency: order.currency,
         payment_method: order.payment_method_id,
-        setup_future_usage: 'off_session',
+        setup_future_usage: "off_session",
 
         // A PaymentIntent can be confirmed some time after creation,
         // but here we want to confirm (collect payment) immediately.
@@ -99,7 +99,7 @@ app.post('/pay', async (req, res) => {
         error_on_requires_action: true,
       })
 
-      if (intent.status === 'succeeded') {
+      if (intent.status === "succeeded") {
         // This creates a new Customer and attaches the PaymentMethod in one API call.
         const customer = await stripe.customers.create({
           payment_method: intent.payment_method,
@@ -117,10 +117,10 @@ app.post('/pay', async (req, res) => {
         // Any other status would be unexpected, so error
         res
           .status(400)
-          .json({ error: { message: 'Unexpected status ' + intent.status } })
+          .json({ error: { message: "Unexpected status " + intent.status } })
       }
     } catch (error) {
-      if (error.type === 'StripeCardError') {
+      if (error.type === "StripeCardError") {
         // Display error to customer
         res.status(400).json({ error: error.raw })
       } else {
@@ -131,7 +131,7 @@ app.post('/pay', async (req, res) => {
   } else {
     res
       .status(400)
-      .json({ error: 'Order amount does not match product prices.' })
+      .json({ error: "Order amount does not match product prices." })
   }
 })
 

--- a/snippets.js/express_server.js
+++ b/snippets.js/express_server.js
@@ -1,0 +1,138 @@
+// Online example: https://runkit.com/thor-stripe/gocommerce-clone-api
+const express = require('express')
+const app = express()
+const port = 3000
+
+const fetch = require('isomorphic-unfetch')
+const DomParser = require('dom-parser')
+const parser = new DomParser()
+
+const stripe = require('stripe')(process.env.JAMSTACK_SECRET_KEY)
+
+// Constants
+const SITE_URL = 'https://53806382.ngrok.io/'
+// Helper functions
+const getProductData = async url => {
+  // Get the product meta from the static page
+  const doc = await fetch(url).then(async res => {
+    const htmlString = await res.text()
+    return parser.parseFromString(htmlString, 'text/html')
+  })
+  if (doc.getElementsByClassName('gocommerce-product').length !== 1) {
+    throw new Error('None or too many product data declarations!')
+    return
+  }
+  // Replace HTML special chars
+  const jsonString = doc
+    .getElementsByClassName('gocommerce-product')[0]
+    .innerHTML.replace(/&quot;/g, `"`)
+  return JSON.parse(jsonString)
+}
+const calculateOrderAmount = ({ order, products }) => {
+  let validatedAmount = 0
+  order.cart.forEach(item => {
+    // Get product by sku
+    const product = products.find(product => product.sku === item.sku)
+    // Get price by currency
+    const price = product.prices.find(price => {
+      return price.currency === order.currency
+    })
+    if (!price)
+      throw new Error(
+        `${product.sku} has no price info for currency ${order.currency}`
+      )
+    validatedAmount += Number(price.amount)
+  })
+  return validatedAmount
+}
+
+// use body-parser to automatically parse JSON-encoded request bodies
+const bodyParser = require('body-parser')
+app.use(bodyParser.json())
+
+// Allow cors
+app.use('/', function(req, res, next) {
+  // Allow requests from localhost.
+  const allowedOrigins = ['http://localhost:9000'] // port that's used when running gatsby serve
+  const origin = req.headers.origin
+  if (allowedOrigins.indexOf(origin) > -1) {
+    res.setHeader('Access-Control-Allow-Headers', '*')
+    res.setHeader('Access-Control-Allow-Origin', origin)
+  }
+  next()
+})
+
+app.post('/pay', async (req, res) => {
+  const { order } = req.body
+  const skuIds = order.cart.map(item => item.sku)
+
+  const promises = skuIds.map(
+    sku =>
+      new Promise(async (resolve, reject) => {
+        try {
+          const product = await getProductData(`${SITE_URL}${sku}`)
+          resolve(product)
+        } catch (error) {
+          reject(error)
+        }
+      })
+  )
+  // Wait for all producst to be fetched
+  const products = await Promise.all(promises)
+  const totalAmount = calculateOrderAmount({ order, products })
+  if (totalAmount === Number(order.amount)) {
+    // Create Payment
+    try {
+      const intent = await stripe.paymentIntents.create({
+        amount: totalAmount * 100, // TODO zero decimal currency detection
+        currency: order.currency,
+        payment_method: order.payment_method_id,
+        setup_future_usage: 'off_session',
+
+        // A PaymentIntent can be confirmed some time after creation,
+        // but here we want to confirm (collect payment) immediately.
+        confirm: true,
+
+        // If the payment requires any follow-up actions from the
+        // customer, like two-factor authentication, Stripe will error
+        // and you will need to prompt them for a new payment method.
+        error_on_requires_action: true,
+      })
+
+      if (intent.status === 'succeeded') {
+        // This creates a new Customer and attaches the PaymentMethod in one API call.
+        const customer = await stripe.customers.create({
+          payment_method: intent.payment_method,
+          email: order.email,
+          address: order.address,
+        })
+        // Handle post-payment fulfillment
+        console.log(
+          `Created Payment: ${intent.id} for Customer: ${customer.id}`
+        )
+        // Now ship those goodies
+        // await inventoryAPI.ship(order)
+        res.json({ payment: intent, customer })
+      } else {
+        // Any other status would be unexpected, so error
+        res
+          .status(400)
+          .json({ error: { message: 'Unexpected status ' + intent.status } })
+      }
+    } catch (error) {
+      if (error.type === 'StripeCardError') {
+        // Display error to customer
+        res.status(400).json({ error: error.raw })
+      } else {
+        // Something else happened
+        res.status(400).json({ error })
+      }
+    }
+  } else {
+    res
+      .status(400)
+      .json({ error: 'Order amount does not match product prices.' })
+  }
+})
+
+app.listen(port, () => console.log(`Example API listening on port ${port}!`))

--- a/snippets.js/lambda.js
+++ b/snippets.js/lambda.js
@@ -1,13 +1,13 @@
 // https://stripe.com/docs/payments/without-card-authentication
-const stripe = require('stripe')('API_KEY')
+const stripe = require("stripe")("API_KEY")
 
 exports.handler = async event => {
-  if (!event.body || event.httpMethod !== 'POST') {
+  if (!event.body || event.httpMethod !== "POST") {
     return {
       statusCode: 400,
       headers,
       body: JSON.stringify({
-        status: 'invalid http method',
+        status: "invalid http method",
       }),
     }
   }
@@ -25,7 +25,7 @@ exports.handler = async event => {
   try {
     const intent = await stripe.paymentIntents.create({
       amount: calculateOrderAmount(order.items),
-      currency: 'usd',
+      currency: "usd",
       payment_method: order.payment_method_id,
 
       // A PaymentIntent can be confirmed some time after creation,
@@ -38,7 +38,7 @@ exports.handler = async event => {
       error_on_requires_action: true,
     })
 
-    if (intent.status === 'succeeded') {
+    if (intent.status === "succeeded") {
       // This creates a new Customer and attaches the PaymentMethod in one API call.
       const customer = await stripe.customers.create({
         payment_method: intent.payment_method,
@@ -51,10 +51,10 @@ exports.handler = async event => {
       await inventoryAPI.ship(order)
     } else {
       // Any other status would be unexpected, so error
-      console.log({ error: 'Unexpected status ' + intent.status })
+      console.log({ error: "Unexpected status " + intent.status })
     }
   } catch (e) {
-    if (e.type === 'StripeCardError') {
+    if (e.type === "StripeCardError") {
       // Display error to customer
       console.log({ error: e.message })
     } else {

--- a/snippets.js/lambda.js
+++ b/snippets.js/lambda.js
@@ -1,13 +1,13 @@
 // https://stripe.com/docs/payments/without-card-authentication
-const stripe = require("stripe")("API_KEY")
+const stripe = require('stripe')('API_KEY')
 
 exports.handler = async event => {
-  if (!event.body || event.httpMethod !== "POST") {
+  if (!event.body || event.httpMethod !== 'POST') {
     return {
       statusCode: 400,
       headers,
       body: JSON.stringify({
-        status: "invalid http method",
+        status: 'invalid http method',
       }),
     }
   }
@@ -18,13 +18,14 @@ exports.handler = async event => {
     // Replace this constant with a calculation of the order's amount
     // You should always calculate the order total on the server to prevent
     // people from directly manipulating the amount on the client
+    // See example implementation in ../snippets.js/express_server.js
     return 1400
   }
 
   try {
     const intent = await stripe.paymentIntents.create({
       amount: calculateOrderAmount(order.items),
-      currency: "usd",
+      currency: 'usd',
       payment_method: order.payment_method_id,
 
       // A PaymentIntent can be confirmed some time after creation,
@@ -37,7 +38,7 @@ exports.handler = async event => {
       error_on_requires_action: true,
     })
 
-    if (intent.status === "succeeded") {
+    if (intent.status === 'succeeded') {
       // This creates a new Customer and attaches the PaymentMethod in one API call.
       const customer = await stripe.customers.create({
         payment_method: intent.payment_method,
@@ -50,10 +51,10 @@ exports.handler = async event => {
       await inventoryAPI.ship(order)
     } else {
       // Any other status would be unexpected, so error
-      console.log({ error: "Unexpected status " + intent.status })
+      console.log({ error: 'Unexpected status ' + intent.status })
     }
   } catch (e) {
-    if (e.type === "StripeCardError") {
+    if (e.type === 'StripeCardError') {
       // Display error to customer
       console.log({ error: e.message })
     } else {

--- a/src/components/commerce/CommerceMetaData.js
+++ b/src/components/commerce/CommerceMetaData.js
@@ -1,12 +1,12 @@
 // https://github.com/netlify/gocommerce#what-your-static-site-must-support
-import React from 'react'
+import React from "react"
 
 const CommerceMetaData = ({ item }) => (
   <script className="gocommerce-product" type="application/json">
     {JSON.stringify({
       sku: item.sku,
       title: item.name,
-      prices: [{ amount: item.price, currency: 'usd' }], // TODO: Move currency into config file.
+      prices: [{ amount: item.price, currency: "usd" }], // TODO: Move currency into config file.
     })}
   </script>
 )

--- a/src/components/commerce/CommerceMetaData.js
+++ b/src/components/commerce/CommerceMetaData.js
@@ -1,0 +1,14 @@
+// https://github.com/netlify/gocommerce#what-your-static-site-must-support
+import React from 'react'
+
+const CommerceMetaData = ({ item }) => (
+  <script className="gocommerce-product" type="application/json">
+    {JSON.stringify({
+      sku: item.sku,
+      title: item.name,
+      prices: [{ amount: item.price, currency: 'usd' }], // TODO: Move currency into config file.
+    })}
+  </script>
+)
+
+export default CommerceMetaData

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -1,24 +1,24 @@
-import React, { useState } from 'react'
+import React, { useState } from "react"
 
-import { SiteContext, ContextProviderComponent } from '../context/mainContext'
-import { DENOMINATION } from '../../providers/inventoryProvider'
-import { FaLongArrowAltLeft } from 'react-icons/fa'
-import { Link } from 'gatsby'
-import Image from '../components/Image'
-import { fetchPostJSON } from '../../utils/helpers'
-import uuid from 'uuid/v4'
+import { SiteContext, ContextProviderComponent } from "../context/mainContext"
+import { DENOMINATION } from "../../providers/inventoryProvider"
+import { FaLongArrowAltLeft } from "react-icons/fa"
+import { Link } from "gatsby"
+import Image from "../components/Image"
+import { fetchPostJSON } from "../../utils/helpers"
+import uuid from "uuid/v4"
 
 import {
   CardElement,
   Elements,
   useStripe,
   useElements,
-} from '@stripe/react-stripe-js'
-import { loadStripe } from '@stripe/stripe-js'
+} from "@stripe/react-stripe-js"
+import { loadStripe } from "@stripe/stripe-js"
 
 // Make sure to call `loadStripe` outside of a component’s render to avoid
 // recreating the `Stripe` object on every render.
-const stripePromise = loadStripe('pk_test_9LMKfbJSTwlckL4EIOeakphR00W7j9f6MJ')
+const stripePromise = loadStripe("pk_test_9LMKfbJSTwlckL4EIOeakphR00W7j9f6MJ")
 
 function CheckoutWithContext(props) {
   return (
@@ -53,12 +53,12 @@ const Checkout = ({ context }) => {
   const [errorMessage, setErrorMessage] = useState(null)
   const [orderCompleted, setOrderCompleted] = useState(false)
   const [input, setInput] = useState({
-    name: '',
-    email: '',
-    street: '',
-    city: '',
-    postal_code: '',
-    state: '',
+    name: "",
+    email: "",
+    street: "",
+    city: "",
+    postal_code: "",
+    state: "",
   })
 
   const stripe = useStripe()
@@ -82,7 +82,7 @@ const Checkout = ({ context }) => {
 
     // Validate input
     if (!street || !city || !postal_code || !state) {
-      setErrorMessage('Please fill in the form!')
+      setErrorMessage("Please fill in the form!")
       return
     }
 
@@ -96,7 +96,7 @@ const Checkout = ({ context }) => {
       error: stripeError,
       paymentMethod,
     } = await stripe.createPaymentMethod({
-      type: 'card',
+      type: "card",
       card: cardElement,
       billing_details: { name: name },
     })
@@ -111,13 +111,13 @@ const Checkout = ({ context }) => {
       email,
       name,
       amount: total,
-      currency: 'usd', // TODO: Move currency into config file.
+      currency: "usd", // TODO: Move currency into config file.
       address: { line1: street, city, postal_code, state }, // TODO country
       payment_method_id: paymentMethod.id,
-      receipt_email: 'customer@example.com',
+      receipt_email: "customer@example.com",
       id: uuid(),
     }
-    console.log('order: ', order)
+    console.log("order: ", order)
     // Call our lambda endpoint to validate and create the payment
     // See example at https://runkit.com/thor-stripe/gocommerce-clone-api
     // TODO: show processing spinner and lock UI.
@@ -125,7 +125,7 @@ const Checkout = ({ context }) => {
       payment,
       error,
     } = await fetchPostJSON(
-      'https://gocommerce-clone-api-eig8cd0l634r.runkit.sh/pay',
+      "https://gocommerce-clone-api-eig8cd0l634r.runkit.sh/pay",
       { order }
     )
     if (error) {
@@ -197,7 +197,7 @@ const Checkout = ({ context }) => {
               <div className="flex flex-1 pt-8 flex-col">
                 <div className="mt-4 border-t pt-10">
                   <form onSubmit={handleSubmit}>
-                    {errorMessage ? <span>{errorMessage}</span> : ''}
+                    {errorMessage ? <span>{errorMessage}</span> : ""}
                     <Input
                       onChange={onChange}
                       value={input.name}

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -1,23 +1,24 @@
-import React, { useState } from "react"
+import React, { useState } from 'react'
 
-import { SiteContext, ContextProviderComponent } from "../context/mainContext"
-import { DENOMINATION } from "../../providers/inventoryProvider"
-import { FaLongArrowAltLeft } from "react-icons/fa"
-import { Link } from "gatsby"
-import Image from "../components/Image"
-import uuid from "uuid/v4"
+import { SiteContext, ContextProviderComponent } from '../context/mainContext'
+import { DENOMINATION } from '../../providers/inventoryProvider'
+import { FaLongArrowAltLeft } from 'react-icons/fa'
+import { Link } from 'gatsby'
+import Image from '../components/Image'
+import { fetchPostJSON } from '../../utils/helpers'
+import uuid from 'uuid/v4'
 
 import {
   CardElement,
   Elements,
   useStripe,
   useElements,
-} from "@stripe/react-stripe-js"
-import { loadStripe } from "@stripe/stripe-js"
+} from '@stripe/react-stripe-js'
+import { loadStripe } from '@stripe/stripe-js'
 
 // Make sure to call `loadStripe` outside of a component’s render to avoid
 // recreating the `Stripe` object on every render.
-const stripePromise = loadStripe("pk_test_DvXwcKnVaaZUpWJIbh9cjgZr00IjIAjZAA")
+const stripePromise = loadStripe('pk_test_9LMKfbJSTwlckL4EIOeakphR00W7j9f6MJ')
 
 function CheckoutWithContext(props) {
   return (
@@ -52,12 +53,12 @@ const Checkout = ({ context }) => {
   const [errorMessage, setErrorMessage] = useState(null)
   const [orderCompleted, setOrderCompleted] = useState(false)
   const [input, setInput] = useState({
-    name: "",
-    email: "",
-    street: "",
-    city: "",
-    postal_code: "",
-    state: "",
+    name: '',
+    email: '',
+    street: '',
+    city: '',
+    postal_code: '',
+    state: '',
   })
 
   const stripe = useStripe()
@@ -71,7 +72,7 @@ const Checkout = ({ context }) => {
   const handleSubmit = async event => {
     event.preventDefault()
     const { name, email, street, city, postal_code, state } = input
-    const { total, clearCart } = context
+    const { total, clearCart, cart } = context
 
     if (!stripe || !elements) {
       // Stripe.js has not loaded yet. Make sure to disable
@@ -81,7 +82,7 @@ const Checkout = ({ context }) => {
 
     // Validate input
     if (!street || !city || !postal_code || !state) {
-      setErrorMessage("Please fill in the form!")
+      setErrorMessage('Please fill in the form!')
       return
     }
 
@@ -91,27 +92,47 @@ const Checkout = ({ context }) => {
     const cardElement = elements.getElement(CardElement)
 
     // Use your card Element with other Stripe.js APIs
-    const { error, paymentMethod } = await stripe.createPaymentMethod({
-      type: "card",
+    const {
+      error: stripeError,
+      paymentMethod,
+    } = await stripe.createPaymentMethod({
+      type: 'card',
       card: cardElement,
       billing_details: { name: name },
     })
 
-    if (error) {
-      setErrorMessage(error.message)
+    if (stripeError) {
+      setErrorMessage(stripeError.message)
       return
     }
 
     const order = {
+      cart,
       email,
+      name,
       amount: total,
-      address: state, // should this be {street, city, postal_code, state} ?
+      currency: 'usd', // TODO: Move currency into config file.
+      address: { line1: street, city, postal_code, state }, // TODO country
       payment_method_id: paymentMethod.id,
-      receipt_email: "customer@example.com",
+      receipt_email: 'customer@example.com',
       id: uuid(),
     }
-    console.log("order: ", order)
-    // TODO call API
+    console.log('order: ', order)
+    // Call our lambda endpoint to validate and create the payment
+    // See example at https://runkit.com/thor-stripe/gocommerce-clone-api
+    // TODO: show processing spinner and lock UI.
+    const {
+      payment,
+      error,
+    } = await fetchPostJSON(
+      'https://gocommerce-clone-api-eig8cd0l634r.runkit.sh/pay',
+      { order }
+    )
+    if (error) {
+      setErrorMessage(error.message)
+      return
+    }
+    console.log({ payment })
     setOrderCompleted(true)
     clearCart()
   }
@@ -176,7 +197,7 @@ const Checkout = ({ context }) => {
               <div className="flex flex-1 pt-8 flex-col">
                 <div className="mt-4 border-t pt-10">
                   <form onSubmit={handleSubmit}>
-                    {errorMessage ? <span>{errorMessage}</span> : ""}
+                    {errorMessage ? <span>{errorMessage}</span> : ''}
                     <Input
                       onChange={onChange}
                       value={input.name}

--- a/src/templates/ItemView.js
+++ b/src/templates/ItemView.js
@@ -1,11 +1,11 @@
-import React from 'react'
-import Button from '../components/Button'
+import React from "react"
+import Button from "../components/Button"
 
-import { SiteContext, ContextProviderComponent } from '../context/mainContext'
-import CartLink from '../components/CartLink'
-import Image from '../components/Image'
-import CommerceMetaData from '../components/commerce/CommerceMetaData'
-import { slugify } from '../../utils/helpers'
+import { SiteContext, ContextProviderComponent } from "../context/mainContext"
+import CartLink from "../components/CartLink"
+import Image from "../components/Image"
+import CommerceMetaData from "../components/commerce/CommerceMetaData"
+import { slugify } from "../../utils/helpers"
 
 const ItemView = props => {
   const item = props.pageContext.content

--- a/src/templates/ItemView.js
+++ b/src/templates/ItemView.js
@@ -4,26 +4,37 @@ import Button from '../components/Button'
 import { SiteContext, ContextProviderComponent } from '../context/mainContext'
 import CartLink from '../components/CartLink'
 import Image from '../components/Image'
+import CommerceMetaData from '../components/commerce/CommerceMetaData'
+import { slugify } from '../../utils/helpers'
 
-const ItemView = (props) => {
+const ItemView = props => {
   const item = props.pageContext.content
   const { price, image, name, description } = item
-  const { context: { addToCart }} = props
+  item.sku = slugify(name)
+  const {
+    context: { addToCart },
+  } = props
 
-  function addItemToCart (item) {
+  function addItemToCart(item) {
     addToCart(item)
   }
 
   return (
     <>
       <CartLink />
-      <div className="py-12 flex flex-1 flex-col
+      <div
+        className="py-12 flex flex-1 flex-col
       md:flex-row
       w-full
-      my-0 mx-auto">
+      my-0 mx-auto"
+      >
         <div className="w-full md:w-1/2 h-112 flex flex-1 bg-light hover:bg-light-200">
           <div className="py-16 p10 flex flex-1 justify-center items-center">
-            <Image src={image} className="max-w-lg m-0 max-h-96 w-64 md:w-full" alt="Inventory item"  />
+            <Image
+              src={image}
+              className="max-w-lg m-0 max-h-96 w-64 md:w-full"
+              alt="Inventory item"
+            />
           </div>
         </div>
         <div className="pt-2 px-0 md:px-10 pb-8 w-full md:w-1/2">
@@ -37,22 +48,19 @@ const ItemView = (props) => {
           />
         </div>
       </div>
+      <CommerceMetaData item={item} />
     </>
   )
 }
-
 
 function ItemViewWithContext(props) {
   return (
     <ContextProviderComponent>
       <SiteContext.Consumer>
-        {
-          context =>  <ItemView {...props} context={context} />
-        }
+        {context => <ItemView {...props} context={context} />}
       </SiteContext.Consumer>
     </ContextProviderComponent>
   )
 }
-
 
 export default ItemViewWithContext

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,36 +1,36 @@
 function slugify(string) {
   const a =
-    'àáäâãåăæąçćčđďèéěėëêęğǵḧìíïîįłḿǹńňñòóöôœøṕŕřßşśšșťțùúüûǘůűūųẃẍÿýźžż·/_,:;'
+    "àáäâãåăæąçćčđďèéěėëêęğǵḧìíïîįłḿǹńňñòóöôœøṕŕřßşśšșťțùúüûǘůűūųẃẍÿýźžż·/_,:;"
   const b =
-    'aaaaaaaaacccddeeeeeeegghiiiiilmnnnnooooooprrsssssttuuuuuuuuuwxyyzzz------'
-  const p = new RegExp(a.split('').join('|'), 'g')
+    "aaaaaaaaacccddeeeeeeegghiiiiilmnnnnooooooprrsssssttuuuuuuuuuwxyyzzz------"
+  const p = new RegExp(a.split("").join("|"), "g")
 
   return string
     .toString()
     .toLowerCase()
-    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(/\s+/g, "-") // Replace spaces with -
     .replace(p, c => b.charAt(a.indexOf(c))) // Replace special characters
-    .replace(/&/g, '-and-') // Replace & with 'and'
-    .replace(/[^\w-]+/g, '') // Remove all non-word characters
-    .replace(/--+/g, '-') // Replace multiple - with single -
-    .replace(/^-+/, '') // Trim - from start of text
-    .replace(/-+$/, '') // Trim - from end of text
+    .replace(/&/g, "-and-") // Replace & with 'and'
+    .replace(/[^\w-]+/g, "") // Remove all non-word characters
+    .replace(/--+/g, "-") // Replace multiple - with single -
+    .replace(/^-+/, "") // Trim - from start of text
+    .replace(/-+$/, "") // Trim - from end of text
 }
 
 function titleIfy(slug) {
-  var words = slug.split('-')
+  var words = slug.split("-")
   for (var i = 0; i < words.length; i++) {
     var word = words[i]
     words[i] = word.charAt(0).toUpperCase() + word.slice(1)
   }
-  return words.join(' ')
+  return words.join(" ")
 }
 
 function getTrimmedString(string, length = 8) {
   if (string.length <= length) {
     return string
   } else {
-    return string.substring(0, length) + '...'
+    return string.substring(0, length) + "..."
   }
 }
 
@@ -38,16 +38,16 @@ async function fetchPostJSON(url, data) {
   try {
     // Default options are marked with *
     const response = await fetch(url, {
-      method: 'POST', // *GET, POST, PUT, DELETE, etc.
-      mode: 'cors', // no-cors, *cors, same-origin
-      cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-      credentials: 'same-origin', // include, *same-origin, omit
+      method: "POST", // *GET, POST, PUT, DELETE, etc.
+      mode: "cors", // no-cors, *cors, same-origin
+      cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
+      credentials: "same-origin", // include, *same-origin, omit
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         // 'Content-Type': 'application/x-www-form-urlencoded',
       },
-      redirect: 'follow', // manual, *follow, error
-      referrerPolicy: 'no-referrer', // no-referrer, *client
+      redirect: "follow", // manual, *follow, error
+      referrerPolicy: "no-referrer", // no-referrer, *client
       body: JSON.stringify(data || {}), // body data type must match "Content-Type" header
     })
     return await response.json() // parses JSON response into native JavaScript objects

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,9 +1,13 @@
 function slugify(string) {
-  const a = 'àáäâãåăæąçćčđďèéěėëêęğǵḧìíïîįłḿǹńňñòóöôœøṕŕřßşśšșťțùúüûǘůűūųẃẍÿýźžż·/_,:;'
-  const b = 'aaaaaaaaacccddeeeeeeegghiiiiilmnnnnooooooprrsssssttuuuuuuuuuwxyyzzz------'
+  const a =
+    'àáäâãåăæąçćčđďèéěėëêęğǵḧìíïîįłḿǹńňñòóöôœøṕŕřßşśšșťțùúüûǘůűūųẃẍÿýźžż·/_,:;'
+  const b =
+    'aaaaaaaaacccddeeeeeeegghiiiiilmnnnnooooooprrsssssttuuuuuuuuuwxyyzzz------'
   const p = new RegExp(a.split('').join('|'), 'g')
 
-  return string.toString().toLowerCase()
+  return string
+    .toString()
+    .toLowerCase()
     .replace(/\s+/g, '-') // Replace spaces with -
     .replace(p, c => b.charAt(a.indexOf(c))) // Replace special characters
     .replace(/&/g, '-and-') // Replace & with 'and'
@@ -14,12 +18,12 @@ function slugify(string) {
 }
 
 function titleIfy(slug) {
-  var words = slug.split('-');
+  var words = slug.split('-')
   for (var i = 0; i < words.length; i++) {
-    var word = words[i];
-    words[i] = word.charAt(0).toUpperCase() + word.slice(1);
+    var word = words[i]
+    words[i] = word.charAt(0).toUpperCase() + word.slice(1)
   }
-  return words.join(' ');
+  return words.join(' ')
 }
 
 function getTrimmedString(string, length = 8) {
@@ -30,6 +34,26 @@ function getTrimmedString(string, length = 8) {
   }
 }
 
-export {
-  slugify, titleIfy, getTrimmedString
+async function fetchPostJSON(url, data) {
+  try {
+    // Default options are marked with *
+    const response = await fetch(url, {
+      method: 'POST', // *GET, POST, PUT, DELETE, etc.
+      mode: 'cors', // no-cors, *cors, same-origin
+      cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+      credentials: 'same-origin', // include, *same-origin, omit
+      headers: {
+        'Content-Type': 'application/json',
+        // 'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      redirect: 'follow', // manual, *follow, error
+      referrerPolicy: 'no-referrer', // no-referrer, *client
+      body: JSON.stringify(data || {}), // body data type must match "Content-Type" header
+    })
+    return await response.json() // parses JSON response into native JavaScript objects
+  } catch (err) {
+    throw new Error(err.message)
+  }
 }
+
+export { slugify, titleIfy, getTrimmedString, fetchPostJSON }


### PR DESCRIPTION
* `snippets.js/express_server.js` showcases an express server that can validate product amounts based on static site metadata, same approach as https://github.com/netlify/gocommerce#what-your-static-site-must-support

## How to set up & test
* Deploy the express_server.js somewhere or clone https://runkit.com/thor-stripe/gocommerce-clone-api on Runkit
* fire up ngrok `ngrok http 9000` and put it the ngrok URL as SITE_URL in the express_server.
* in `pages/checkout.js` update the URL in `fetchPostJSON` to point to your server/function
* run `gatsby build`
* run `gatsby serve`