### PR TITLE
add image popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-helmet": "^5.2.1",
     "react-icons": "^3.9.0",
     "react-toastify": "^5.5.0",
+    "reactjs-popup": "^1.5.0",
     "tailwindcss": "^1.1.4",
     "uuid": "^3.4.0"
   },

--- a/src/templates/ItemView.js
+++ b/src/templates/ItemView.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import Button from '../components/Button'
+import Popup from "reactjs-popup"
 
 import { SiteContext, ContextProviderComponent } from '../context/mainContext'
 import CartLink from '../components/CartLink'
+import Button from '../components/Button'
 import Image from '../components/Image'
 
 const ItemView = (props) => {
@@ -23,7 +24,9 @@ const ItemView = (props) => {
       my-0 mx-auto">
         <div className="w-full md:w-1/2 h-112 flex flex-1 bg-light hover:bg-light-200">
           <div className="py-16 p10 flex flex-1 justify-center items-center">
-            <Image src={image} className="max-w-lg m-0 max-h-96 w-64 md:w-full" alt="Inventory item"  />
+            <Popup modal trigger={<img src={image} className="max-w-lg m-0 max-h-96 w-64 md:w-full" alt="Inventory item" />}>
+              <Image src={image} alt="Inventory item" />
+            </Popup>
           </div>
         </div>
         <div className="pt-2 px-0 md:px-10 pb-8 w-full md:w-1/2">

--- a/src/templates/ItemView.js
+++ b/src/templates/ItemView.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Popup from "reactjs-popup"
+import Popup from 'reactjs-popup'
 
 import { SiteContext, ContextProviderComponent } from '../context/mainContext'
 import CartLink from '../components/CartLink'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9895,6 +9895,11 @@ react@^16.12.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
+reactjs-popup@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/reactjs-popup/-/reactjs-popup-1.5.0.tgz#09ef15daf9bf932e9adbf595f3976851c24913cf"
+  integrity sha512-9uoxUAcUomnNoBtdYXBmgsF4w46llsogE3tOvLb5IkR5MMrD6UZJK20ip9kDKXCYubSxNkdfQKqSb/c95rf/qA==
+
 read-chunk@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-3.2.0.tgz#2984afe78ca9bfbbdb74b19387bf9e86289c16ca"


### PR DESCRIPTION
On the _Item View_ template, when you click the image, it popups up in a modal div.

This adds a dependency; but, the dep itself has no other deps.